### PR TITLE
fix ID location inside JSONRPC2 response

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -65,5 +65,5 @@ func ExampleEchoHandler_ServeJSONRPC() {
 	}
 
 	// Output:
-	// {"id":"243a718a-2ebb-4e32-8cc8-210c39e8a14b","jsonrpc":"2.0","result":{"message":"Hello, John Doe"}}
+	// {"jsonrpc":"2.0","result":{"message":"Hello, John Doe"},"id":"243a718a-2ebb-4e32-8cc8-210c39e8a14b"}
 }

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -20,18 +20,18 @@ const (
 type (
 	// A Request represents a JSON-RPC request received by the server.
 	Request struct {
-		ID      *fastjson.RawMessage `json:"id"`
 		Version string               `json:"jsonrpc"`
 		Method  string               `json:"method"`
 		Params  *fastjson.RawMessage `json:"params"`
+		ID      *fastjson.RawMessage `json:"id"`
 	}
 
 	// A Response represents a JSON-RPC response returned by the server.
 	Response struct {
-		ID      *fastjson.RawMessage `json:"id,omitempty"`
 		Version string               `json:"jsonrpc"`
 		Result  interface{}          `json:"result,omitempty"`
 		Error   *Error               `json:"error,omitempty"`
+		ID      *fastjson.RawMessage `json:"id,omitempty"`
 	}
 )
 

--- a/jsonrpc_test.go
+++ b/jsonrpc_test.go
@@ -95,18 +95,18 @@ func TestSendResponse(t *testing.T) {
 	rec = httptest.NewRecorder()
 	err = SendResponse(rec, []*Response{r}, false)
 	require.NoError(t, err)
-	assert.Equal(t, `{"id":"test","jsonrpc":"2.0","result":{"name":"john"}}
+	assert.Equal(t, `{"jsonrpc":"2.0","result":{"name":"john"},"id":"test"}
 `, rec.Body.String())
 
 	rec = httptest.NewRecorder()
 	err = SendResponse(rec, []*Response{r}, true)
 	require.NoError(t, err)
-	assert.Equal(t, `[{"id":"test","jsonrpc":"2.0","result":{"name":"john"}}]
+	assert.Equal(t, `[{"jsonrpc":"2.0","result":{"name":"john"},"id":"test"}]
 `, rec.Body.String())
 
 	rec = httptest.NewRecorder()
 	err = SendResponse(rec, []*Response{r, r}, false)
 	require.NoError(t, err)
-	assert.Equal(t, `[{"id":"test","jsonrpc":"2.0","result":{"name":"john"}},{"id":"test","jsonrpc":"2.0","result":{"name":"john"}}]
+	assert.Equal(t, `[{"jsonrpc":"2.0","result":{"name":"john"},"id":"test"},{"jsonrpc":"2.0","result":{"name":"john"},"id":"test"}]
 `, rec.Body.String())
 }


### PR DESCRIPTION
This makes JSONRPC2 response just like inside [specification](https://www.jsonrpc.org/specification), ID should be last element

Signed-off-by: s3rj1k <evasive.gyron@gmail.com>