### PR TITLE
fix gometalinter config

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,64 +1,71 @@
 {
-    "Deadline":"5m",
-    "EnableGC":true,
-    "Disable":[
-       "dupl"
-    ],
-    "Exclude":[
-       "autogen/.*"
-    ],
-    "Sort":[
-       "path",
-       "line",
-       "column",
-       "severity",
-       "linter"
-    ],
-    "Cyclo":26,
-    "LineLength":200,
-    "Enable":[
-       "deadcode",
-       "errcheck",
-       "gochecknoglobals",
-       "gochecknoinits",
-       "goconst",
-       "gocritic",
-       "gocyclo",
-       "gofmt",
-       "goimports",
-       "golint",
-       "gosec",
-       "gosimple",
-       "gotype",
-       "gotypex",
-       "ineffassign",
-       "interfacer",
-       "lll",
-       "maligned",
-       "megacheck",
-       "misspell",
-       "nakedret",
-       "safesql",
-       "staticcheck",
-       "structcheck",
-       "test",
-       "testify",
-       "unconvert",
-       "unparam",
-       "unused",
-       "varcheck",
-       "vet",
-       "vetshadow"
-    ],
-    "Linters":{
-       "vet":"go tool vet -printfuncs=Logf,Errorf,Infof,Infoerrf,Warningf :PATH:LINE:MESSAGE",
-       "gocritic":{
-          "Command":"gocritic check-package",
-          "Pattern":"^(?P<path>.*?\\.go),(?P<line>\\d+)(-\\d+)?,(?P<message>[^,]+,[^,]+,[^,]+)",
-          "InstallFrom":"github.com/go-critic/go-critic/...",
-          "PartitionStrategy":"packages",
-          "defaultEnabled":true,
-          "IsFast":true
-       }
-    }
- }
+  "Cyclo": 26,
+  "Deadline": "5m",
+  "Disable": [
+    "dupl",
+    "gosimple",
+    "staticcheck",
+    "unused"
+  ],
+  "Enable": [
+    "deadcode",
+    "errcheck",
+    "gochecknoglobals",
+    "gochecknoinits",
+    "goconsistent",
+    "goconst",
+    "gocritic",
+    "gocyclo",
+    "gofmt",
+    "goimports",
+    "golint",
+    "gosec",
+    "gotype",
+    "gotypex",
+    "ineffassign",
+    "interfacer",
+    "lll",
+    "maligned",
+    "megacheck",
+    "misspell",
+    "nakedret",
+    "safesql",
+    "structcheck",
+    "test",
+    "testify",
+    "unconvert",
+    "unparam",
+    "varcheck",
+    "vet",
+    "vetshadow"
+  ],
+  "EnableGC": true,
+  "Exclude": [
+    "autogen/.*"
+  ],
+  "LineLength": 200,
+  "Linters": {
+    "goconsistent": {
+      "Command": "go-consistent -pedantic",
+      "InstallFrom": "github.com/Quasilyte/go-consistent",
+      "IsFast": true,
+      "PartitionStrategy": "single-directory",
+      "Pattern": "^(?P<path>.*\\.go):(?P<line>\\d+):(?P<col>\\d+):\\s*(?P<message>.*)$"
+    },
+    "gocritic": {
+      "Command": "gocritic check-package",
+      "InstallFrom": "github.com/go-critic/go-critic/...",
+      "IsFast": true,
+      "PartitionStrategy": "single-directory",
+      "Pattern": "^(?P<path>.*\\.go):(?P<line>\\d+):(?P<col>\\d+):\\s*(?P<message>.*)$"
+    },
+    "vet": "go tool vet -printfuncs=Logf,Errorf,Infof,Infoerrf,Warningf :PATH:LINE:MESSAGE"
+  },
+  "Sort": [
+    "path",
+    "line",
+    "column",
+    "severity",
+    "linter"
+  ]
+}


### PR DESCRIPTION
this adds go-consistent to linter config, fixes go-critic pattern match and sorts json keys