### PR TITLE
add jsonrpc method metadata to context

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ import (
 
 type requestIDKey struct{}
 type metadataIDKey struct{}
+type methodNameKey struct{}
 
 // RequestID takes request id from context.
 func RequestID(c context.Context) *fastjson.RawMessage {
@@ -19,12 +20,22 @@ func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
 }
 
-// RequestID takes request id from context.
+// GetMetadata takes jsonrpc metadata from context.
 func GetMetadata(c context.Context) Metadata {
 	return c.Value(metadataIDKey{}).(Metadata)
 }
 
-// WithRequestID adds request id to context.
+// WithMetadata adds jsonrpc metadata to context.
 func WithMetadata(c context.Context, md Metadata) context.Context {
 	return context.WithValue(c, metadataIDKey{}, md)
+}
+
+// MethodName takes method name from context.
+func MethodName(c context.Context) string {
+	return c.Value(methodNameKey{}).(string)
+}
+
+// WithMethodName adds method name to context.
+func WithMethodName(c context.Context, name string) context.Context {
+	return context.WithValue(c, methodNameKey{}, name)
 }

--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 )
 
 type requestIDKey struct{}
+type metadataIDKey struct{}
 
 // RequestID takes request id from context.
 func RequestID(c context.Context) *fastjson.RawMessage {
@@ -16,4 +17,14 @@ func RequestID(c context.Context) *fastjson.RawMessage {
 // WithRequestID adds request id to context.
 func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
+}
+
+// RequestID takes request id from context.
+func GetMetadata(c context.Context) Metadata {
+	return c.Value(metadataIDKey{}).(Metadata)
+}
+
+// WithRequestID adds request id to context.
+func WithMetadata(c context.Context, md Metadata) context.Context {
+	return context.WithValue(c, metadataIDKey{}, md)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -19,3 +19,25 @@ func TestRequestID(t *testing.T) {
 	})
 	require.Equal(t, &id, pick)
 }
+func TestMetadata(t *testing.T) {
+
+	c := context.Background()
+	md := Metadata{Params: Metadata{}}
+	c = WithMetadata(c, md)
+	var pick Metadata
+	require.NotPanics(t, func() {
+		pick = GetMetadata(c)
+	})
+	require.Equal(t, md, pick)
+}
+
+func TestMethodName(t *testing.T) {
+
+	c := context.Background()
+	c = WithMethodName(c, t.Name())
+	var pick string
+	require.NotPanics(t, func() {
+		pick = MethodName(c)
+	})
+	require.Equal(t, t.Name(), pick)
+}

--- a/handler.go
+++ b/handler.go
@@ -44,13 +44,15 @@ func (mr *MethodRepository) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // InvokeMethod invokes JSON-RPC method.
 func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Response {
-	var h Handler
+	var md Metadata
 	res := NewResponse(r)
-	h, res.Error = mr.TakeMethod(r)
+	md, res.Error = mr.TakeMethodMetadata(r)
 	if res.Error != nil {
 		return res
 	}
-	res.Result, res.Error = h.ServeJSONRPC(WithRequestID(c, r.ID), r.Params)
+
+	wrappedContext := WithMetadata(WithRequestID(c, r.ID), md)
+	res.Result, res.Error = md.Handler.ServeJSONRPC(wrappedContext, r.Params)
 	if res.Error != nil {
 		res.Result = nil
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -12,14 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type handler struct {
-	F func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error)
-}
-
-func (h *handler) ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
-	return h.F(c, params)
-}
-
 func TestHandler(t *testing.T) {
 
 	mr := NewMethodRepository()
@@ -46,15 +38,13 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, res.Error)
 
-	h1 := &handler{}
-	h1.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h1 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return "hello", nil
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("hello", h1, nil, nil))
-	h2 := &handler{}
-	h2.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h2 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return nil, ErrInternal()
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("bye", h2, nil, nil))
 
 	rec = httptest.NewRecorder()

--- a/method.go
+++ b/method.go
@@ -27,20 +27,20 @@ func NewMethodRepository() *MethodRepository {
 	}
 }
 
-// TakeMethod takes jsonrpc.Func in MethodRepository.
-func (mr *MethodRepository) TakeMethod(r *Request) (Handler, *Error) {
+// TakeMethodMetadata takes metadata in MethodRepository for request.
+func (mr *MethodRepository) TakeMethodMetadata(r *Request) (Metadata, *Error) {
 	if r.Method == "" || r.Version != Version {
-		return nil, ErrInvalidParams()
+		return Metadata{}, ErrInvalidParams()
 	}
 
 	mr.m.RLock()
 	md, ok := mr.r[r.Method]
 	mr.m.RUnlock()
 	if !ok {
-		return nil, ErrMethodNotFound()
+		return Metadata{}, ErrMethodNotFound()
 	}
 
-	return md.Handler, nil
+	return md, nil
 }
 
 // RegisterMethod registers jsonrpc.Func to MethodRepository.

--- a/method_test.go
+++ b/method_test.go
@@ -62,10 +62,9 @@ func TestMethods(t *testing.T) {
 }
 
 func SampleHandler() Handler {
-	h := handler{}
-	h.F = func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
+	h := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
 		return nil, nil
-	}
+	})
 	return &h
 }
 

--- a/method_test.go
+++ b/method_test.go
@@ -9,30 +9,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTakeMethod(t *testing.T) {
+func TestTakeMethodMetadata(t *testing.T) {
 
 	mr := NewMethodRepository()
 
 	r := &Request{}
-	_, err := mr.TakeMethod(r)
+	_, err := mr.TakeMethodMetadata(r)
 	require.IsType(t, &Error{}, err)
 	assert.Equal(t, ErrorCodeInvalidParams, err.Code)
 
 	r.Method = "test"
-	_, err = mr.TakeMethod(r)
+	_, err = mr.TakeMethodMetadata(r)
 	require.IsType(t, &Error{}, err)
 	assert.Equal(t, ErrorCodeInvalidParams, err.Code)
 
 	r.Version = "2.0"
-	_, err = mr.TakeMethod(r)
+	_, err = mr.TakeMethodMetadata(r)
 	require.IsType(t, &Error{}, err)
 	assert.Equal(t, ErrorCodeMethodNotFound, err.Code)
 
 	require.NoError(t, mr.RegisterMethod("test", SampleHandler(), nil, nil))
 
-	f, err := mr.TakeMethod(r)
+	md, err := mr.TakeMethodMetadata(r)
 	require.Nil(t, err)
-	assert.NotEmpty(t, f)
+	assert.NotEmpty(t, md)
 }
 
 func TestRegisterMethod(t *testing.T) {
@@ -67,4 +67,21 @@ func SampleHandler() Handler {
 		return nil, nil
 	}
 	return &h
+}
+
+type ExampleParam struct {
+}
+
+func TestMetadataInContext(t *testing.T) {
+
+	mr := NewMethodRepository()
+
+	err := mr.RegisterMethod(t.Name(), SampleHandler(), ExampleParam{}, nil)
+	require.NoError(t, err)
+
+	r := &Request{Method: t.Name(), Version: "2.0"}
+	md, err := mr.TakeMethodMetadata(r)
+	require.Nil(t, err)
+	assert.Equal(t, ExampleParam{}, md.Params)
+
 }


### PR DESCRIPTION
## WHAT

- Write the change being made with this pull request.
add jsonrpc Metadata to context

## WHY

- Write the motivation why you submit this pull request.
I need it in my project and I thin it can be useful for all. And I see no harm from this.
Metadata in context allows to know jsonrpc method name for common logging, or 'params' allows unmarhal parameter as a common step of handling.
All this benefits when there is multiple-layer handling of jsonrpc request in complex api`s
