### PR TITLE
Add method name to the context

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 )
 
 type requestIDKey struct{}
+type methodNameKey struct{}
 
 // RequestID takes request id from context.
 func RequestID(c context.Context) *fastjson.RawMessage {
@@ -16,4 +17,14 @@ func RequestID(c context.Context) *fastjson.RawMessage {
 // WithRequestID adds request id to context.
 func WithRequestID(c context.Context, id *fastjson.RawMessage) context.Context {
 	return context.WithValue(c, requestIDKey{}, id)
+}
+
+// MethodName takes method name from context.
+func MethodName(c context.Context) string {
+	return c.Value(methodNameKey{}).(string)
+}
+
+// WithMethodName adds method name to context.
+func WithMethodName(c context.Context, name string) context.Context {
+	return context.WithValue(c, methodNameKey{}, name)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -19,3 +19,14 @@ func TestRequestID(t *testing.T) {
 	})
 	require.Equal(t, &id, pick)
 }
+
+func TestMethodName(t *testing.T) {
+
+	c := context.Background()
+	c = WithMethodName(c, t.Name())
+	var pick string
+	require.NotPanics(t, func() {
+		pick = MethodName(c)
+	})
+	require.Equal(t, t.Name(), pick)
+}

--- a/handler.go
+++ b/handler.go
@@ -50,9 +50,10 @@ func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Respons
 	if res.Error != nil {
 		return res
 	}
+
 	wrappedContext := WithRequestID(c, r.ID)
 	wrappedContext = WithMethodName(wrappedContext, r.Method)
-	res.Result, res.Error = h.ServeJSONRPC(WithRequestID(c, r.ID), r.Params)
+	res.Result, res.Error = h.ServeJSONRPC(wrappedContext, r.Params)
 	if res.Error != nil {
 		res.Result = nil
 	}

--- a/handler.go
+++ b/handler.go
@@ -50,6 +50,8 @@ func (mr *MethodRepository) InvokeMethod(c context.Context, r *Request) *Respons
 	if res.Error != nil {
 		return res
 	}
+	wrappedContext := WithRequestID(c, r.ID)
+	wrappedContext = WithMethodName(wrappedContext, r.Method)
 	res.Result, res.Error = h.ServeJSONRPC(WithRequestID(c, r.ID), r.Params)
 	if res.Error != nil {
 		res.Result = nil


### PR DESCRIPTION
## WHAT
see header
## WHY
it`s convenient to have name of current jsonrpc method in context. For logging purposes as example. 
