### PR TITLE
Add HandlerFunc implementation

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,17 @@ type Handler interface {
 	ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error)
 }
 
+// HandlerFunc type is an adapter to allow the use of
+// ordinary functions as JSONRPC handlers. If f is a function
+// with the appropriate signature, HandlerFunc(f) is a
+// jsonrpc.Handler that calls f.
+type HandlerFunc func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error)
+
+// ServeJSONRPC calls f(w, r).
+func (f HandlerFunc) ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
+	return f(c, params)
+}
+
 // ServeHTTP provides basic JSON-RPC handling.
 func (mr *MethodRepository) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -12,14 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type handler struct {
-	F func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error)
-}
-
-func (h *handler) ServeJSONRPC(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
-	return h.F(c, params)
-}
-
 func TestHandler(t *testing.T) {
 
 	mr := NewMethodRepository()
@@ -46,15 +38,13 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, res.Error)
 
-	h1 := &handler{}
-	h1.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h1 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return "hello", nil
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("hello", h1, nil, nil))
-	h2 := &handler{}
-	h2.F = func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
+	h2 := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (interface{}, *Error) {
 		return nil, ErrInternal()
-	}
+	})
 	require.NoError(t, mr.RegisterMethod("bye", h2, nil, nil))
 
 	rec = httptest.NewRecorder()

--- a/method_test.go
+++ b/method_test.go
@@ -62,9 +62,9 @@ func TestMethods(t *testing.T) {
 }
 
 func SampleHandler() Handler {
-	h := handler{}
-	h.F = func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
+
+	h := HandlerFunc(func(c context.Context, params *fastjson.RawMessage) (result interface{}, err *Error) {
 		return nil, nil
-	}
+	})
 	return &h
 }


### PR DESCRIPTION
a small step to middleware implementation

## WHAT
Full analog of golang`s http.HandlerFunc for jsonrpc handlers 

## WHY
something like syntax sugar. Allows to all practices developed for http.Handler be usable for jsonrpc.Handler
