### PR TITLE
Update package name due to #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: If you use Go 1.6, see [v1.0](https://github.com/osamingo/jsonrpc/releases
 ## Install
 
 ```
-$ go get -u github.com/osamingo/jsonrpc
+$ go get -u github.com/osamingo/jsonrpc/v2
 ```
 
 ## Usage
@@ -35,7 +35,7 @@ import (
 	"net/http"
 
 	"github.com/intel-go/fastjson"
-	"github.com/osamingo/jsonrpc"
+	"github.com/osamingo/jsonrpc/v2"
 )
 
 type (
@@ -108,7 +108,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/osamingo/jsonrpc"
+	"github.com/osamingo/jsonrpc/v2"
 )
 
 type (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/osamingo/jsonrpc/v2
+module github.com/alexus1024/jsonrpc/v2
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/osamingo/jsonrpc
+module github.com/osamingo/jsonrpc/v2
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alexus1024/jsonrpc/v2
+module github.com/osamingo/jsonrpc/v2
 
 go 1.13
 


### PR DESCRIPTION
## WHAT

Updated module name to /v2 according to last tag

## WHY

Motivation is greatly described in #43 

## Additional actions

After merging should add new tag (e.g. "v2.3.1") for the module to begin be usable
